### PR TITLE
Add Vibe Drama link to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,12 @@
         <li><a href="dramaplay1a.html">The Flame We Nurture</a> – Chapter 1: A Spark in the Dark</li>
       </ul>
     </section>
+
+    <section>
+      <h2>Vibe Drama</h2>
+      <p>An experimental text-to-speech playground for hearing your lines performed in different voices.</p>
+      <p><a href="vibedrama/vibedrama.html">Launch Vibe Drama</a></p>
+    </section>
   </main>
 
   <footer>


### PR DESCRIPTION
## Summary
- Add dedicated Vibe Drama section to homepage with link to new interactive page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af8815ac1c832dbb44d944e06a3057